### PR TITLE
Added deprecation notice block above changelog

### DIFF
--- a/content/reference/api/changelog.md
+++ b/content/reference/api/changelog.md
@@ -1,7 +1,7 @@
 +++
 title = "API Changelog"
 description = "Description of all changes affecting the public Giant Swarm API, in reverse chronological order."
-date = "2015-06-02"
+date = "2015-06-03"
 type = "page"
 categories = ["Reference", "API"]
 tags = ["api"]
@@ -11,6 +11,12 @@ weight = 100
 # API Changelog
 
 Here we list all changes affecting the mechanics of our public [API](/reference/api/), including new functionality and bug fixes, in reverse chronological order.
+
+<div class="well">
+<h4>Deprecation Notice</h4>
+<p>Route <code>/v1/org/{org}/env/{env}/app/</code>: The output provides, per listed application, the two keys <code>org</code> and <code>company</code> with identical values. Please prepare for the legacy <code>company</code> key disappearing some time soon.
+</div>
+
 
 ## 2015-06-02
 

--- a/content/reference/api/changelog.md
+++ b/content/reference/api/changelog.md
@@ -14,7 +14,8 @@ Here we list all changes affecting the mechanics of our public [API](/reference/
 
 <div class="well">
 <h4>Deprecation Notice</h4>
-<p>Route <code>/v1/org/{org}/env/{env}/app/</code>: The output provides, per listed application, the two keys <code>org</code> and <code>company</code> with identical values. Please prepare for the legacy <code>company</code> key disappearing some time soon.
+<p>Route <code>/v1/org/{org}/env/{env}/app/</code>: The output provides, per listed application, the two keys <code>org</code> and <code>company</code> with identical values. Please prepare for the legacy <code>company</code> key disappearing after June 30, 2015.</p>
+<p>Previous, undocumented API versions provided methods under routes starting with <code>/v1/company/</code>. Please use the according routes starting with <code>/v1/org/</code>. All routes under <code>/v1/company/</code> are deprecated and won't be provided any longer after June 30, 2015.</p>
 </div>
 
 


### PR DESCRIPTION
Ping @kordless @puja108 @ZeissS : I thought it was a good idea to keep track of upcoming API changes we know of.

What I find sub-optimal is the fact that "some time soon" is not very precise. "by the end of June" or "by June 30" would be better, I think. But this also means that we will have to leave things as they are until then. Can we do that?