### PR TITLE
docs-content: Added core namespace functionality

### DIFF
--- a/content/reference/swarm-json.md
+++ b/content/reference/swarm-json.md
@@ -89,7 +89,24 @@ This example makes use of all possible keys to illustrate their use.
         {
           "component_name": "redis",
           "image": "dockerfile/redis",
-          "ports": [ 6379 ]
+          "ports": [ 6379 ],
+          "namespace<TDB>": "redis-group",
+          "volumes": [
+            {
+              "path": "/var/data",
+              "size": "10 GB"
+            }
+          ]
+        },
+        {
+          "component_name": "redis-backup",
+          "image": "custom/my-redis-backup-image",
+          "namespace<TBD>": "redis-group",
+          "volumes": [
+            {
+              "volumes-from": "redis"
+            }
+          ]
         }
       ]
     }
@@ -287,6 +304,14 @@ The Object given with this key can have two optional keys:
 
 Note that there currently is a hard [limit](https://giantswarm.io/limits/) of 10 instances per component.
 
+### `namespace<TBD>`
+
+With the `namespace<TBD>` property you can group components closer together. All components in a `namespace<TBD>` share the same IP address, TCP/UDP port space, IPC objects, optionally share volumes and they will be scheduled on the same machine. If one of the components fail, all others will be restart as well.
+
+To put multiple components in a single `namespace<TBD>`, give all of them the same value for the `namespace<TBD>` property. Note that you can only group components from a single service together.
+
+If you scale a component in a `namespace<TBD>` all components in that group will be scaled. Note that each group on scaled instances will have their own namespaces and can be scheduled on different machines.
+
 ### `volumes`
 
 When you stop an application component, all data written to the file system in the docker container representing this component is lost. With volumes you can preserve your data to survive stops and starts. The volumes you define will be created when the application is created and will be deleted upon application deletion.
@@ -295,6 +320,16 @@ The `volumes` key expects an array of simple objects as value, one object for ea
 
 * `path`: The path in which the volume will be mounted, as a string
 * `size`: A string defining the volume size in gigabytes in a format like `<n> GB`.
+
+or
+
+* `volumes-from`: The name of another component in the same `namespace<TBD>`. This component will have all volumes from the referenced component mounted at the same mount points.
+
+or
+
+* `volume-from`: The name of another component in the same `namespace<TBD>`. 
+* `volume-path`: The `path` of a volume in the component referenced by `volume-from`. This volume from the referenced component will be mounted inside this component.
+* `path` (optional): If specified, this will be used as mounting point of the volume from the referenced component. If not specific, the mounting point will be equal to the mounting point of the referenced component.
 
 <i class="fa fa-exclamation-triangle"></i> Please note that we currently do not provide a backup mechanism. If you need to preserve the data on your volumes, please think about a solution using for example an FTP server or cloud storage like Amazon S3 from within your component.
 

--- a/content/reference/swarm-json.md
+++ b/content/reference/swarm-json.md
@@ -90,7 +90,7 @@ This example makes use of all possible keys to illustrate their use.
           "component_name": "redis",
           "image": "dockerfile/redis",
           "ports": [ 6379 ],
-          "namespace<TDB>": "redis-group",
+          "pod": "redis-group",
           "volumes": [
             {
               "path": "/var/data",
@@ -101,7 +101,7 @@ This example makes use of all possible keys to illustrate their use.
         {
           "component_name": "redis-backup",
           "image": "custom/my-redis-backup-image",
-          "namespace<TBD>": "redis-group",
+          "pod": "redis-group",
           "volumes": [
             {
               "volumes-from": "redis"
@@ -304,13 +304,13 @@ The Object given with this key can have two optional keys:
 
 Note that there currently is a hard [limit](https://giantswarm.io/limits/) of 10 instances per component.
 
-### `namespace<TBD>`
+### `pod`
 
-With the `namespace<TBD>` property you can group components closer together. All components in a `namespace<TBD>` share the same IP address, TCP/UDP port space, IPC objects, optionally share volumes, and will be scheduled on the same machine. If one of the components fails, all others in the group will be restarted as well.
+With the `pod` property you can group components closer together. All components in a `pod` share the same IP address, TCP/UDP port space, IPC objects, optionally share volumes, and will be scheduled on the same machine. If one of the components fails, all others in the group will be restarted as well.
 
-To put multiple components in a single `namespace<TBD>`, give the `namespace<TBD>` property the same value for all of them. Note that you can only group components from a single service.
+To put multiple components in a single `pod`, give the `pod` property the same value for all of them. Note that you can only group components from a single service.
 
-If you scale a component in a `namespace<TBD>` all components in that group will be scaled. Note that each group of scaled instances will have their own namespaces and can be scheduled on different machines. Thus, each group of component instances is only part of their respective namspaces on one host, instances on different hosts do not share namespaces.
+If you scale a component in a `pod` all components in that group will be scaled. Note that each group of scaled instances will have their own namespaces and can be scheduled on different machines. Thus, each group of component instances is only part of their respective namspaces on one host, instances on different hosts do not share namespaces.
 
 ### `volumes`
 
@@ -323,11 +323,11 @@ The `volumes` key expects an array of simple objects as value, one object for ea
 
 or
 
-* `volumes-from`: The name of another component in the same `namespace<TBD>`. This component will have all volumes from the referenced component mounted at the same mount points.
+* `volumes-from`: The name of another component in the same `pod`. This component will have all volumes from the referenced component mounted at the same mount points.
 
 or
 
-* `volume-from`: The name of another component in the same `namespace<TBD>`. 
+* `volume-from`: The name of another component in the same `pod`. 
 * `volume-path`: The `path` of a volume in the component referenced by `volume-from`. This volume from the referenced component will be mounted inside this component.
 * `path` (optional): If specified, this will be used as mounting point of the volume from the referenced component. If not specified, the mounting point will be equal to the mounting point of the referenced component.
 

--- a/content/reference/swarm-json.md
+++ b/content/reference/swarm-json.md
@@ -308,9 +308,9 @@ Note that there currently is a hard [limit](https://giantswarm.io/limits/) of 10
 
 With the `namespace<TBD>` property you can group components closer together. All components in a `namespace<TBD>` share the same IP address, TCP/UDP port space, IPC objects, optionally share volumes, and will be scheduled on the same machine. If one of the components fails, all others in the group will be restarted as well.
 
-To put multiple components in a single `namespace<TBD>`, give all of them the same value in the `namespace<TBD>` property. Note that you can only group components from a single service.
+To put multiple components in a single `namespace<TBD>`, give the `namespace<TBD>` property the same value for all of them. Note that you can only group components from a single service.
 
-If you scale a component in a `namespace<TBD>` all components in that group will be scaled. Note that each group of scaled instances will have their own namespace and can be scheduled on different machines. However, the grouping only occurs intra-machine, i.e. no instances are grouped between machines.
+If you scale a component in a `namespace<TBD>` all components in that group will be scaled. Note that each group of scaled instances will have their own namespaces and can be scheduled on different machines. Thus, each group of component instances is only part of their respective namspaces on one host, instances on different hosts do not share namespaces.
 
 ### `volumes`
 

--- a/content/reference/swarm-json.md
+++ b/content/reference/swarm-json.md
@@ -306,11 +306,11 @@ Note that there currently is a hard [limit](https://giantswarm.io/limits/) of 10
 
 ### `namespace<TBD>`
 
-With the `namespace<TBD>` property you can group components closer together. All components in a `namespace<TBD>` share the same IP address, TCP/UDP port space, IPC objects, optionally share volumes and they will be scheduled on the same machine. If one of the components fail, all others will be restart as well.
+With the `namespace<TBD>` property you can group components closer together. All components in a `namespace<TBD>` share the same IP address, TCP/UDP port space, IPC objects, optionally share volumes, and will be scheduled on the same machine. If one of the components fails, all others in the group will be restarted as well.
 
-To put multiple components in a single `namespace<TBD>`, give all of them the same value for the `namespace<TBD>` property. Note that you can only group components from a single service together.
+To put multiple components in a single `namespace<TBD>`, give all of them the same value in the `namespace<TBD>` property. Note that you can only group components from a single service.
 
-If you scale a component in a `namespace<TBD>` all components in that group will be scaled. Note that each group on scaled instances will have their own namespaces and can be scheduled on different machines.
+If you scale a component in a `namespace<TBD>` all components in that group will be scaled. Note that each group of scaled instances will have their own namespace and can be scheduled on different machines. However, the grouping only occurs intra-machine, i.e. no instances are grouped between machines.
 
 ### `volumes`
 
@@ -318,7 +318,7 @@ When you stop an application component, all data written to the file system in t
 
 The `volumes` key expects an array of simple objects as value, one object for each volume you want to define. Each of these objects must have the following keys:
 
-* `path`: The path in which the volume will be mounted, as a string
+* `path`: The path, in which the volume will be mounted, as a string
 * `size`: A string defining the volume size in gigabytes in a format like `<n> GB`.
 
 or
@@ -329,7 +329,7 @@ or
 
 * `volume-from`: The name of another component in the same `namespace<TBD>`. 
 * `volume-path`: The `path` of a volume in the component referenced by `volume-from`. This volume from the referenced component will be mounted inside this component.
-* `path` (optional): If specified, this will be used as mounting point of the volume from the referenced component. If not specific, the mounting point will be equal to the mounting point of the referenced component.
+* `path` (optional): If specified, this will be used as mounting point of the volume from the referenced component. If not specified, the mounting point will be equal to the mounting point of the referenced component.
 
 <i class="fa fa-exclamation-triangle"></i> Please note that we currently do not provide a backup mechanism. If you need to preserve the data on your volumes, please think about a solution using for example an FTP server or cloud storage like Amazon S3 from within your component.
 


### PR DESCRIPTION
This change adds a description of the `namespace` feature.

Note that the term for `namespace` is still undecided, therefore I've postfixed it with `<TBD>` everywhere.