### PR TITLE
Added install block on Windows

### DIFF
--- a/content/reference/cli/installation.md
+++ b/content/reference/cli/installation.md
@@ -1,7 +1,7 @@
 +++
 title = "Installing the Giant Swarm CLI"
 description = "A detailed description of how to install Giant Swarm client software on various platforms"
-date = "2015-07-03"
+date = "2015-07-06"
 type = "page"
 weight = 10
 +++
@@ -64,7 +64,17 @@ $ sudo cp swarm /usr/local/bin/
 
 ## Windows {#windows}
 
-Currently, we don't offer the swarm CLI for Windows. However, you can run it in a Linux virtual machine like the one used by [Boot2Docker](https://docs.docker.com/installation/windows/). Simply log in to Boot2Docker's virtual machine via `boot2docker ssh` and follow the installation instructions for Linux ([see above](#linux)).
+Currently, we don't offer the swarm CLI for Windows. However, you can run it in a Linux virtual machine like the one used by [Boot2Docker](https://docs.docker.com/installation/windows/). Note that this requires a 64 bit version of Windows. Follow this procedure for installing the CLI:
+
+1. Start Boot2Docker
+2. Log in to Boot2Docker's virtual machine via the command line and the command `boot2docker ssh`
+3. Execute `curl -O http://downloads.giantswarm.io/swarm/clients/{{% cli_latest_version %}}/swarm-{{% cli_latest_version %}}-linux-amd64.tar.gz`
+4. Execute `tar xzf swarm-{{% cli_latest_version %}}-linux-amd64.tar.gz`
+5. Execute `sudo cp ./swarm /usr/local/bin/`
+6. Check your install using the `swarm info` command
+
+Whenever you need the swarm CLI, execute steps one 1 and 2 of this procedure and you should be ready to go. To update the CLI, follow the same routine as for the first-time install.
+
 
 ## Using an HTTP proxy
 

--- a/content/reference/cli/installation.md
+++ b/content/reference/cli/installation.md
@@ -1,7 +1,7 @@
 +++
 title = "Installing the Giant Swarm CLI"
 description = "A detailed description of how to install Giant Swarm client software on various platforms"
-date = "2015-02-01"
+date = "2015-07-03"
 type = "page"
 weight = 10
 +++
@@ -10,9 +10,9 @@ weight = 10
 
 <p class="lead">Instructions for installing the <code>swarm</code> command line interface on the supported platforms. By the way, the latest version is <strong>{{% cli_latest_version %}}</strong>.</p>
 
-## Mac OS X
+## Mac OS X {#macosx}
 
-### Mac OS X install via Homebrew
+### Mac OS X install via Homebrew {#macosx-homebrew}
 
 If you're on a Mac, the recommended way to install the `swarm` command line interface (CLI) is to use [Homebrew](http://brew.sh/).
 
@@ -30,7 +30,7 @@ $ brew update
 $ brew upgrade swarm-client
 ```
 
-### Mac OS X manual install
+### Mac OS X manual install {#macosx-manual}
 
 If you don't want to use Homebrew, here is how you could download and install the <abbr title="command line interface">CLI</abbr> manually.
 
@@ -43,7 +43,7 @@ To check the integrity of the downloaded .tar.gz file, we provide [SHA1](http://
 
 Please add the `swarm` binary to your PATH.
 
-## Linux
+## Linux {#linux}
 
 Please note that the `swarm` <abbr title="command line interface">CLI</abbr> requires a 64 bit system.
 
@@ -61,6 +61,10 @@ We recommend to make the `swarm` binary available in your PATH by copying it to 
 ```nohighlight
 $ sudo cp swarm /usr/local/bin/
 ```
+
+## Windows {#windows}
+
+Currently, we don't offer the swarm CLI for Windows. However, you can run it in a Linux virtual machine like the one used by [Boot2Docker](https://docs.docker.com/installation/windows/). Simply log in to Boot2Docker's virtual machine via `boot2docker ssh` and follow the installation instructions for Linux ([see above](#linux)).
 
 ## Using an HTTP proxy
 

--- a/content/reference/cli/installation.md
+++ b/content/reference/cli/installation.md
@@ -64,10 +64,10 @@ $ sudo cp swarm /usr/local/bin/
 
 ## Windows {#windows}
 
-Currently, we don't offer the swarm CLI for Windows. However, you can run it in a Linux virtual machine like the one used by [Boot2Docker](https://docs.docker.com/installation/windows/). Note that this requires a 64 bit version of Windows. Follow this procedure for installing the CLI:
+Currently, we don't offer the swarm CLI for Windows. However, you can run it in a Linux virtual machine like the one used by [Boot2Docker](https://docs.docker.com/installation/windows/). Note that this, like Docker itself, requires a 64 bit version of Windows. Follow this procedure for installing the CLI:
 
 1. Start Boot2Docker
-2. Log in to Boot2Docker's virtual machine via the command line and the command `boot2docker ssh`
+2. Log in to Boot2Docker's virtual machine via the command line using the command `boot2docker ssh`
 3. Execute `curl -O http://downloads.giantswarm.io/swarm/clients/{{% cli_latest_version %}}/swarm-{{% cli_latest_version %}}-linux-amd64.tar.gz`
 4. Execute `tar xzf swarm-{{% cli_latest_version %}}-linux-amd64.tar.gz`
 5. Execute `sudo cp ./swarm /usr/local/bin/`

--- a/content/reference/cli/installation.md
+++ b/content/reference/cli/installation.md
@@ -73,7 +73,7 @@ Currently, we don't offer the swarm CLI for Windows. However, you can run it in 
 5. Execute `sudo cp ./swarm /usr/local/bin/`
 6. Check your install using the `swarm info` command
 
-Whenever you need the swarm CLI, execute steps one 1 and 2 of this procedure and you should be ready to go. To update the CLI, follow the same routine as for the first-time install.
+Whenever you need the swarm CLI, execute first two steps of this procedure and you should be ready to go. To update the CLI, follow the same routine as for the first-time install.
 
 
 ## Using an HTTP proxy

--- a/content/reference/cli/installation.md
+++ b/content/reference/cli/installation.md
@@ -73,7 +73,7 @@ Currently, we don't offer the swarm CLI for Windows. However, you can run it in 
 5. Execute `sudo cp ./swarm /usr/local/bin/`
 6. Check your install using the `swarm info` command
 
-Whenever you need the swarm CLI, execute first two steps of this procedure and you should be ready to go. To update the CLI, follow the same routine as for the first-time install.
+Whenever you need the swarm CLI, execute the first two steps of this procedure and you should be ready to go. To update the CLI, follow the same routine as for the first-time install.
 
 
 ## Using an HTTP proxy


### PR DESCRIPTION
@webwurst @luebken @kordless @puja108 - Is anybody of you able to test how logging in to the boot2docker VM works on Windows? Assuming it's the same as on Mac, it should be `boot2docker ssh`, but I'd like confirmation before we publish this.
