### PR TITLE
reference/cli: fix a few typos

### DIFF
--- a/content/reference/cli/cat.md
+++ b/content/reference/cli/cat.md
@@ -1,7 +1,7 @@
 +++
 title = "Getting an application's configuration"
 description = "This is the reference page for the 'swarm cat' command, which allows you to fetch the effective configuration of an application."
-date = "2015-01-29"
+date = "2015-07-25"
 type = "page"
 categories = ["Reference", "Swarm CLI Commands"]
 tags = ["swarm cat"]
@@ -30,7 +30,7 @@ The `app_name` argument is optional when there is a proper `swarm.json` file in 
 
 ## Output
 
-The effective application configuration is printed in JSON format. VIf variables were used when creating the application, they are replaced with their respective values.
+The effective application configuration is printed in JSON format. If variables were used when creating the application, they are replaced with their respective values.
 
 ## Further reading
 

--- a/content/reference/cli/start.md
+++ b/content/reference/cli/start.md
@@ -1,7 +1,7 @@
 +++
 title = "Starting an application or service"
 description = "This is the reference page for the 'swarm start' command, which allows you to start an application or service."
-date = "2014-12-11"
+date = "2015-07-25"
 type = "page"
 categories = ["Reference", "Swarm CLI Commands"]
 tags = ["swarm start"]
@@ -26,7 +26,7 @@ The optional `app_name` argument specifies the application to be started. It ref
 
 If the `app_name` (and `service_name`) argument is ommitted, the CLI looks if there is a `swarm.json` [application configuration](/reference/swarm-json/) file in the current directory. If this is the case, the application defined in that configuration file is started.
 
-The flag `-d` or `--detach` can be used to immediately exit the command after issuing the command to the API. When immitted, the command is running until the application is either running an error occurs.
+The flag `-d` or `--detach` can be used to immediately exit the command after issuing the command to the API. When ommitted, the command is running until the application is either running or an error occurs.
 
 ## Starting an application
 


### PR DESCRIPTION
- cat: removes a capital `v` before an `if`;
- start: changes `immitted` to `ommitted`;
- start: add a missing `or`.